### PR TITLE
improve filter augmentation

### DIFF
--- a/include/idocp/line_search/line_search_filter.hpp
+++ b/include/idocp/line_search/line_search_filter.hpp
@@ -1,7 +1,7 @@
 #ifndef IDOCP_LINE_SEARCH_FILTER_HPP_
 #define IDOCP_LINE_SEARCH_FILTER_HPP_
 
-#include <vector>
+#include <set>
 #include <utility>
 
 
@@ -75,7 +75,7 @@ public:
   bool isEmpty() const;
 
 private:
-  std::vector<std::pair<double, double>> filter_;
+  std::set<std::pair<double, double>> filter_;
   double cost_reduction_rate_, constraints_reduction_rate_;
 
 };

--- a/src/line_search/line_search_filter.cpp
+++ b/src/line_search/line_search_filter.cpp
@@ -34,34 +34,36 @@ LineSearchFilter::~LineSearchFilter() {
 bool LineSearchFilter::isAccepted(const double cost, 
                                   const double constraint_violation) {
   assert(constraint_violation >= 0);
-  if (!filter_.empty()) {
-    for (auto pair : filter_) {
-      if (cost >= pair.first && constraint_violation >= pair.second) {
-        return false;
-      }
-    }
+  if (filter_.empty()) {
+    return true;
   }
-  return true;
+  auto it = filter_.lower_bound(std::make_pair(cost, constraint_violation));
+  if (it == filter_.begin()) {
+    return true;
+  }
+  std::pair<double, double> prev = *(--it);
+  if (cost < prev.first || constraint_violation < prev.second) {
+    return true;
+  }
+  return false;
 }
 
 
 void LineSearchFilter::augment(const double cost, 
                                const double constraint_violation) {
   assert(constraint_violation >= 0);
-  if (!filter_.empty()) {
-    std::vector<std::pair<double, double>>::iterator it = filter_.begin();
-    while (it != filter_.end()) {
-      if (cost <= it->first && constraint_violation <= it->second) {
+  const double new_cost = cost - cost_reduction_rate_ * constraint_violation;
+  const double new_constraint_violation = (1 - constraints_reduction_rate_) * constraint_violation;
+  auto result = filter_.insert(std::make_pair(new_cost, new_constraint_violation));
+  auto it = ++(result.first);
+  while (it != filter_.end()) {
+    if (cost <= it->first && constraint_violation <= it->second) {
         it = filter_.erase(it);
-      }
-      else {
-        ++it;
-      }
+    }
+    else {
+      break;
     }
   }
-  filter_.push_back(std::make_pair(
-      cost-cost_reduction_rate_*constraint_violation, 
-      (1-constraints_reduction_rate_)*constraint_violation));
 }
 
 


### PR DESCRIPTION
We can improve filter augmentation algorithm by storing pairs in an ordered set instead of an array.

Say we have a new candidate (we call this x) for the filter:

First, we don’t have to actually check with all the existing elements in the filter. Instead, we only need the element whose cost is next to x.cost (and you can get such an element in O(logN)). And we can see if x is not dominated by this element, x is not dominated by any of the elements in the filter. This is because when you sort the pairs in ascending order by cost, the constraints violations are always in descending order, as long as we don’t have a dominated pair in the filter.

Second, when x is successfully inserted as ith element of the ordered set, i+1th element could be dominated by x, and in such a case it should be removed from the filter. And if i+1th is so, i+2th could also be a dominated element. However, if ith does not dominate i+1, we don’t have to check elements anymore. Therefore, removal of elements will not occur more than a total number of candidates, resulting the solution O(NlogN).