### PR TITLE
add backtracking line search

### DIFF
--- a/include/robotoc/impulse/impulse_split_solution.hpp
+++ b/include/robotoc/impulse/impulse_split_solution.hpp
@@ -201,6 +201,12 @@ public:
   void copyDual(const ImpulseSplitSolution& another);
 
   ///
+  /// @brief Return L-infinity Norm of the lagrange multipliers. Used in
+  /// line search.
+  ///
+  double lagrangeMultiplierLinfNorm() const;
+
+  ///
   /// @brief Return true if two ImpulseSplitSolution have the same value and  
   /// false if not. 
   /// @param[in] other Impulse split solution that is compared with this object.

--- a/include/robotoc/impulse/impulse_split_solution.hxx
+++ b/include/robotoc/impulse/impulse_split_solution.hxx
@@ -197,14 +197,10 @@ inline void ImpulseSplitSolution::copyDual(const ImpulseSplitSolution& other) {
 }
 
 inline double ImpulseSplitSolution::lagrangeMultiplierLinfNorm() const {
-  const double lmd_linf = lmd.array().abs().maxCoeff();
-  const double gmm_linf = gmm.array().abs().maxCoeff();
-  const double beta_linf = beta.array().abs().maxCoeff();
-  double mu_linf = 0;
-  for (int i=0; i<f.size(); ++i) {
-    const double linf = mu[i].array().abs().maxCoeff();
-    mu_linf = ((mu_linf < linf) ? linf : mu_linf);
-  }
+  const double lmd_linf = lmd.template lpNorm<Eigen::Infinity>();
+  const double gmm_linf = gmm.template lpNorm<Eigen::Infinity>();
+  const double beta_linf = beta.template lpNorm<Eigen::Infinity>();
+  const double mu_linf = ((dimi_ > 0) ? mu_stack().template lpNorm<Eigen::Infinity>() : 0);
   return std::max({lmd_linf, gmm_linf, beta_linf, mu_linf});
 }
 

--- a/include/robotoc/impulse/impulse_split_solution.hxx
+++ b/include/robotoc/impulse/impulse_split_solution.hxx
@@ -196,6 +196,17 @@ inline void ImpulseSplitSolution::copyDual(const ImpulseSplitSolution& other) {
   set_mu_stack();
 }
 
+inline double ImpulseSplitSolution::lagrangeMultiplierLinfNorm() const {
+  const double lmd_linf = lmd.array().abs().maxCoeff();
+  const double gmm_linf = gmm.array().abs().maxCoeff();
+  const double beta_linf = beta.array().abs().maxCoeff();
+  double mu_linf = 0;
+  for (int i=0; i<f.size(); ++i) {
+    const double linf = mu[i].array().abs().maxCoeff();
+    mu_linf = ((mu_linf < linf) ? linf : mu_linf);
+  }
+  return std::max({lmd_linf, gmm_linf, beta_linf, mu_linf});
+}
 
 inline bool ImpulseSplitSolution::isApprox(
     const ImpulseSplitSolution& other) const {

--- a/include/robotoc/line_search/line_search_settings.hpp
+++ b/include/robotoc/line_search/line_search_settings.hpp
@@ -1,0 +1,100 @@
+#ifndef ROBOTOC_LINE_SEARCH_SETTINGS_HPP_
+#define ROBOTOC_LINE_SEARCH_SETTINGS_HPP_
+
+#include <string>
+
+
+namespace robotoc {
+
+///
+/// @class LineSearchSettings
+/// @brief Settings for the line search. 
+///
+class LineSearchSettings {
+public:
+  ///
+  /// @brief Construct an object storing line search settings.
+  /// @param[in] line_search_method If set to "filter", filter method is used
+  /// as a search scheme. If set to "merit-backtracking",
+  /// backtracking line search is used.
+  /// @param[in] step_size_reduction_rate Reduction rate of the step size. 
+  /// @param[in] min_step_size Minimum step size.
+  /// @param[in] armijo_control_rate Control rate in Armijo condition. This value 
+  /// sets the slope of the linear approximation in the Armijo condition.
+  /// @param[in] margin_rate Margin rate to determine penalty parameter in
+  /// the merit function.
+  ///
+  LineSearchSettings(const std::string& line_search_method,
+                     const double step_size_reduction_rate, 
+                     const double min_step_size, 
+                     const double armijo_control_rate,
+                     const double margin_rate);
+
+  ///
+  /// @brief Default constructor. 
+  ///
+  LineSearchSettings();
+
+  ///
+  /// @brief Destructor. 
+  ///
+  ~LineSearchSettings();
+
+  ///
+  /// @brief Default copy constructor. 
+  ///
+  LineSearchSettings(const LineSearchSettings&) = default;
+
+  ///
+  /// @brief Default copy assign operator. 
+  ///
+  LineSearchSettings& operator=(const LineSearchSettings&) = default;
+
+  ///
+  /// @brief Default move constructor. 
+  ///
+  LineSearchSettings(LineSearchSettings&&) noexcept = default;
+
+  ///
+  /// @brief Default move assign operator. 
+  ///
+  LineSearchSettings& operator=(LineSearchSettings&&) noexcept = default;
+
+  ///
+  /// @brief If set to "filter", filter method is used
+  /// as a search scheme. If set to "merit-backtracking",
+  /// backtracking line search is used.
+  ///
+  std::string line_search_method;
+
+  ///
+  /// @brief Reduction rate of the step size.
+  ///
+  double step_size_reduction_rate;
+
+  ///
+  /// @brief Minimum step size.
+  ///
+  double min_step_size;
+
+  ///
+  /// @brief Control rate in Armijo condition. This value 
+  /// sets the slope of the linear approximation in the Armijo condition.
+  ///
+  double armijo_control_rate;
+
+  ///
+  /// @brief Margin rate to determine penalty parameter in
+  /// the merit function.
+  double margin_rate;
+
+  ///
+  /// @brief Returns settings with default parameters.
+  ///
+  static LineSearchSettings defaultSettings();
+};
+
+} // namespace robotoc
+
+
+#endif // ROBOTOC_LINE_SEARCH_SETTINGS_HPP_

--- a/include/robotoc/line_search/line_search_settings.hpp
+++ b/include/robotoc/line_search/line_search_settings.hpp
@@ -23,12 +23,14 @@ public:
   /// sets the slope of the linear approximation in the Armijo condition.
   /// @param[in] margin_rate Margin rate to determine penalty parameter in
   /// the merit function.
+  /// @param[in] eps  A small positive value. Used to calculate directional derivative.
   ///
   LineSearchSettings(const std::string& line_search_method,
                      const double step_size_reduction_rate, 
                      const double min_step_size, 
                      const double armijo_control_rate,
-                     const double margin_rate);
+                     const double margin_rate,
+                     const double eps);
 
   ///
   /// @brief Default constructor. 
@@ -86,7 +88,13 @@ public:
   ///
   /// @brief Margin rate to determine penalty parameter in
   /// the merit function.
+  ///
   double margin_rate;
+  
+  ///
+  /// @brief A small positive value. Used to calculate directional derivative.
+  ///
+  double eps;
 
   ///
   /// @brief Returns settings with default parameters.

--- a/include/robotoc/ocp/split_solution.hpp
+++ b/include/robotoc/ocp/split_solution.hpp
@@ -268,6 +268,12 @@ public:
   bool isApprox(const SplitSolution& other) const;
 
   ///
+  /// @brief Return L-infinity Norm of the lagrange multipliers. Used in
+  /// line search.
+  ///
+  double lagrangeMultiplierLinfNorm() const;
+
+  ///
   /// @brief Set each component vector by random value based on the current 
   /// contact status. 
   /// @param[in] robot Robot model.

--- a/include/robotoc/ocp/split_solution.hxx
+++ b/include/robotoc/ocp/split_solution.hxx
@@ -273,6 +273,18 @@ inline void SplitSolution::copyDual(const SplitSolution& other) {
   }
 }
 
+inline double SplitSolution::lagrangeMultiplierLinfNorm() const {
+  const double lmd_linf = lmd.array().abs().maxCoeff();
+  const double gmm_linf = gmm.array().abs().maxCoeff();
+  const double beta_linf = beta.array().abs().maxCoeff();
+  const double nu_passive_linf = (has_floating_base_ ? nu_passive.array().abs().maxCoeff() : 0);
+  double mu_linf = 0;
+  for (int i=0; i<f.size(); ++i) {
+    const double linf = mu[i].array().abs().maxCoeff();
+    mu_linf = ((mu_linf < linf) ? linf : mu_linf);
+  }
+  return std::max({lmd_linf, gmm_linf, beta_linf, nu_passive_linf, mu_linf});
+}
 
 inline bool SplitSolution::isApprox(const SplitSolution& other) const {
   if (!q.isApprox(other.q)) {

--- a/include/robotoc/ocp/split_solution.hxx
+++ b/include/robotoc/ocp/split_solution.hxx
@@ -274,16 +274,13 @@ inline void SplitSolution::copyDual(const SplitSolution& other) {
 }
 
 inline double SplitSolution::lagrangeMultiplierLinfNorm() const {
-  const double lmd_linf = lmd.array().abs().maxCoeff();
-  const double gmm_linf = gmm.array().abs().maxCoeff();
-  const double beta_linf = beta.array().abs().maxCoeff();
-  const double nu_passive_linf = (has_floating_base_ ? nu_passive.array().abs().maxCoeff() : 0);
-  double mu_linf = 0;
-  for (int i=0; i<f.size(); ++i) {
-    const double linf = mu[i].array().abs().maxCoeff();
-    mu_linf = ((mu_linf < linf) ? linf : mu_linf);
-  }
-  return std::max({lmd_linf, gmm_linf, beta_linf, nu_passive_linf, mu_linf});
+  const double lmd_linf = lmd.template lpNorm<Eigen::Infinity>();
+  const double gmm_linf = gmm.template lpNorm<Eigen::Infinity>();
+  const double beta_linf = beta.template lpNorm<Eigen::Infinity>();
+  const double nu_passive_linf = (has_floating_base_ ? nu_passive.template lpNorm<Eigen::Infinity>() : 0);
+  const double mu_linf = ((dimf_ > 0) ? mu_stack().template lpNorm<Eigen::Infinity>() : 0);
+  const double xi_linf = ((dimi_ > 0) ? xi_stack().template lpNorm<Eigen::Infinity>() : 0);
+  return std::max({lmd_linf, gmm_linf, beta_linf, nu_passive_linf, mu_linf, xi_linf});
 }
 
 inline bool SplitSolution::isApprox(const SplitSolution& other) const {

--- a/include/robotoc/solver/ocp_solver.hpp
+++ b/include/robotoc/solver/ocp_solver.hpp
@@ -20,7 +20,7 @@
 #include "robotoc/ocp/direct_multiple_shooting.hpp"
 #include "robotoc/riccati/riccati_recursion.hpp"
 #include "robotoc/line_search/line_search.hpp"
-
+#include "robotoc/line_search/line_search_settings.hpp"
 
 namespace robotoc {
 
@@ -202,6 +202,12 @@ public:
   /// @return true if the switching times are consistent. false if not.
   ///
   bool isSwitchingTimeConsistent(const double t);
+
+  ///
+  /// @brief Set settings for line search.
+  /// @param[in] settings Line search settings.
+  ///
+  void setLineSearchSettings(const LineSearchSettings& settings=LineSearchSettings::defaultSettings());
 
   ///
   /// @brief Displays the optimal control problem solver onto a ostream.

--- a/src/line_search/line_search.cpp
+++ b/src/line_search/line_search.cpp
@@ -299,7 +299,7 @@ double LineSearch::meritBacktrackingLineSearch(
 bool LineSearch::armijoCond(const double merit_now, const double merit_next, 
                             const double dd, const double step_size, 
                             const double armijo_control_rate) const {
-  const double diff = armijo_control_rate * step_size * dd * merit_now - merit_next;
+  const double diff = armijo_control_rate * step_size * dd + merit_now - merit_next;
   return ((diff <= 0) ? true : false);
 }
 

--- a/src/line_search/line_search.cpp
+++ b/src/line_search/line_search.cpp
@@ -9,13 +9,11 @@ namespace robotoc {
 
 LineSearch::LineSearch(const Robot& robot, const int N, 
                        const int max_num_impulse, const int nthreads, 
-                       const double step_size_reduction_rate,
-                       const double min_step_size) 
+                       const LineSearchSettings& line_search_settings) 
   : filter_(),
     max_num_impulse_(max_num_impulse), 
     nthreads_(nthreads),
-    step_size_reduction_rate_(step_size_reduction_rate), 
-    min_step_size_(min_step_size),
+    settings_(line_search_settings),
     costs_(Eigen::VectorXd::Zero(N+1)), 
     costs_impulse_(Eigen::VectorXd::Zero(max_num_impulse)), 
     costs_aux_(Eigen::VectorXd::Zero(max_num_impulse)), 
@@ -33,8 +31,7 @@ LineSearch::LineSearch()
   : filter_(),
     max_num_impulse_(0), 
     nthreads_(0),
-    step_size_reduction_rate_(0), 
-    min_step_size_(0),
+    settings_(),
     costs_(), 
     costs_impulse_(), 
     costs_aux_(), 
@@ -59,28 +56,20 @@ double LineSearch::computeStepSize(
     const Direction& d, const double max_primal_step_size) {
   assert(max_primal_step_size > 0);
   assert(max_primal_step_size <= 1);
-  if (filter_.isEmpty()) {
-    computeCostAndViolation(ocp, robots, contact_sequence, q, v, s);
-    filter_.augment(totalCosts(), totalViolations());
-  }
   double primal_step_size = max_primal_step_size;
-  while (primal_step_size > min_step_size_) {
-    computeSolutionTrial(ocp, robots, s, d, primal_step_size);
-    computeCostAndViolation(ocp, robots, contact_sequence, q, v, s_trial_,
-                            primal_step_size);
-    const double total_costs = totalCosts();
-    const double total_violations = totalViolations();
-    if (filter_.isAccepted(total_costs, total_violations)) {
-      filter_.augment(total_costs, total_violations);
-      break;
-    }
-    primal_step_size *= step_size_reduction_rate_;
+  if (settings_.line_search_method == "filter") {
+    primal_step_size = lineSearchFilterMethod(ocp, robots, contact_sequence, 
+                                                q, v, s, d, primal_step_size);
   }
-  if (primal_step_size > min_step_size_) {
+	else if (settings_.line_search_method == "merit-backtracking") {
+    primal_step_size = meritBacktrackingLineSearch(ocp, robots, contact_sequence, 
+                                                     q, v, s, d, primal_step_size);
+  }
+  if (primal_step_size > settings_.min_step_size) {
     return primal_step_size;
   }
   else {
-    return min_step_size_;
+    return settings_.min_step_size;
   }
 }
 
@@ -94,12 +83,10 @@ bool LineSearch::isFilterEmpty() const {
   return filter_.isEmpty();
 }
 
-
 void LineSearch::computeCostAndViolation(
     OCP& ocp, aligned_vector<Robot>& robots, 
     const std::shared_ptr<ContactSequence>& contact_sequence, 
-    const Eigen::VectorXd& q, const Eigen::VectorXd& v, const Solution& s, 
-    const double primal_step_size) {
+    const Eigen::VectorXd& q, const Eigen::VectorXd& v, const Solution& s) {
   assert(robots.size() == nthreads_);
   assert(q.size() == robots[0].dimq());
   assert(v.size() == robots[0].dimv());
@@ -255,6 +242,104 @@ void LineSearch::computeSolutionTrial(const OCP& ocp,
                            s_trial_.lift[lift_index]);
     }
   }
+}
+
+double LineSearch::lineSearchFilterMethod(
+    OCP& ocp, aligned_vector<Robot>& robots, 
+    const std::shared_ptr<ContactSequence>& contact_sequence, 
+    const Eigen::VectorXd& q, const Eigen::VectorXd& v, const Solution& s, 
+    const Direction& d, const double initial_primal_step_size) {
+  if (filter_.isEmpty()) {
+    computeCostAndViolation(ocp, robots, contact_sequence, q, v, s);
+    filter_.augment(totalCosts(), totalViolations());
+  }
+  double primal_step_size = initial_primal_step_size;
+  while (primal_step_size > settings_.min_step_size) {
+    computeSolutionTrial(ocp, robots, s, d, primal_step_size);
+    computeCostAndViolation(ocp, robots, contact_sequence, q, v, s_trial_);
+    const double total_costs = totalCosts();
+    const double total_violations = totalViolations();
+    if (filter_.isAccepted(total_costs, total_violations)) {
+      filter_.augment(total_costs, total_violations);
+      break;
+    }
+    primal_step_size *= settings_.step_size_reduction_rate;
+  }
+  return primal_step_size;
+}
+
+double LineSearch::meritBacktrackingLineSearch(
+    OCP& ocp, aligned_vector<Robot>& robots, 
+    const std::shared_ptr<ContactSequence>& contact_sequence, 
+    const Eigen::VectorXd& q, const Eigen::VectorXd& v, const Solution& s, 
+    const Direction& d, const double initial_primal_step_size) {
+  computeCostAndViolation(ocp, robots, contact_sequence, q, v, s);
+  const double penalty_param = penaltyParam(ocp, s);
+  const double merit_now = merit(penalty_param);
+  const double eps = 1.0e-08;
+  computeSolutionTrial(ocp, robots, s, d, eps);
+  computeCostAndViolation(ocp, robots, contact_sequence, q, v, s_trial_);
+  const double merit_eps = merit(penalty_param);
+  const double directional_derivative =  (1.0 / eps) * (merit_eps - merit_now);
+  double primal_step_size = initial_primal_step_size;
+  while (primal_step_size > settings_.min_step_size) {
+    computeSolutionTrial(ocp, robots, s, d, primal_step_size);
+    computeCostAndViolation(ocp, robots, contact_sequence, q, v, s_trial_);
+    const double merit_next = merit(penalty_param);
+    const bool armijoHolds = armijoCond(merit_now, merit_next, directional_derivative, 
+                                        primal_step_size, settings_.armijo_control_rate);
+    if (armijoHolds) {
+      break;
+    }
+    primal_step_size *= settings_.step_size_reduction_rate;
+  }
+  return primal_step_size;
+}
+
+bool LineSearch::armijoCond(const double merit_now, const double merit_next, 
+                            const double dd, const double step_size, 
+                            const double armijo_control_rate) const {
+  const double diff = armijo_control_rate * step_size * dd * merit_now - merit_next;
+  return ((diff <= 0) ? true : false);
+}
+
+double LineSearch::penaltyParam(const OCP& ocp, const Solution& s) const {
+  const int N = ocp.discrete().N();
+  const int N_impulse = ocp.discrete().N_impulse();
+  const int N_lift = ocp.discrete().N_lift();
+  const int N_all = N + 1 + 2*N_impulse + N_lift;
+  Eigen::VectorXd lagrangeMultiplierLinfNorms = Eigen::VectorXd::Zero(N_all);                                        
+  #pragma omp parallel for num_threads(nthreads_)
+  for (int i=0; i<N_all; ++i) {
+    if (i <= N) {
+      lagrangeMultiplierLinfNorms.coeffRef(i) = s[i].lagrangeMultiplierLinfNorm();
+    }
+    else if (i < N+1+N_impulse) {
+      const int impulse_index = i - (N+1);
+      lagrangeMultiplierLinfNorms.coeffRef(i) = s.impulse[impulse_index].lagrangeMultiplierLinfNorm();
+    }
+    else if (i < N+1+2*N_impulse) {
+      const int impulse_index  = i - (N+1+N_impulse);
+      lagrangeMultiplierLinfNorms.coeffRef(i) = s.aux[impulse_index].lagrangeMultiplierLinfNorm();
+    }
+    else {
+      const int lift_index = i - (N+1+2*N_impulse);
+      lagrangeMultiplierLinfNorms.coeffRef(i) = s.lift[lift_index].lagrangeMultiplierLinfNorm();
+    }
+  }
+  return lagrangeMultiplierLinfNorms.maxCoeff() * (1 + settings_.margin_rate);
+}
+
+double LineSearch::merit(const double penalty_param) const {
+  const double res = (costs_ + penalty_param * violations_).sum();
+  const double res_impulse = (costs_impulse_ + penalty_param * violations_impulse_).sum();
+  const double res_aux = (costs_aux_ + penalty_param * violations_aux_).sum();
+  const double res_lift = (costs_lift_ + penalty_param * violations_lift_).sum();                                       
+  return res + res_impulse + res_aux + res_lift;
+}
+
+void LineSearch::set(const LineSearchSettings& settings) {
+  settings_ = settings;
 }
 
 } // namespace robotoc

--- a/src/line_search/line_search.cpp
+++ b/src/line_search/line_search.cpp
@@ -331,7 +331,7 @@ double LineSearch::penaltyParam(const OCP& ocp, const Solution& s) const {
 }
 
 double LineSearch::merit(const double penalty_param) const {
-  const double res = (costs_ + penalty_param * violations_).sum();
+  const double res = (costs_.head(violations_.size()) + penalty_param * violations_).sum() + costs_[violations_.size()];
   const double res_impulse = (costs_impulse_ + penalty_param * violations_impulse_).sum();
   const double res_aux = (costs_aux_ + penalty_param * violations_aux_).sum();
   const double res_lift = (costs_lift_ + penalty_param * violations_lift_).sum();                                       

--- a/src/line_search/line_search.cpp
+++ b/src/line_search/line_search.cpp
@@ -276,11 +276,10 @@ double LineSearch::meritBacktrackingLineSearch(
   computeCostAndViolation(ocp, robots, contact_sequence, q, v, s);
   const double penalty_param = penaltyParam(ocp, s);
   const double merit_now = merit(penalty_param);
-  const double eps = 1.0e-08;
-  computeSolutionTrial(ocp, robots, s, d, eps);
+  computeSolutionTrial(ocp, robots, s, d, settings_.eps);
   computeCostAndViolation(ocp, robots, contact_sequence, q, v, s_trial_);
   const double merit_eps = merit(penalty_param);
-  const double directional_derivative =  (1.0 / eps) * (merit_eps - merit_now);
+  const double directional_derivative =  (1.0 / settings_.eps) * (merit_eps - merit_now);
   double primal_step_size = initial_primal_step_size;
   while (primal_step_size > settings_.min_step_size) {
     computeSolutionTrial(ocp, robots, s, d, primal_step_size);

--- a/src/line_search/line_search_settings.cpp
+++ b/src/line_search/line_search_settings.cpp
@@ -11,12 +11,14 @@ LineSearchSettings::LineSearchSettings(const std::string& line_search_method,
                                        const double step_size_reduction_rate, 
                                        const double min_step_size, 
                                        const double armijo_control_rate,
-                                       const double margin_rate)
+                                       const double margin_rate,
+                                       const double eps)
   : line_search_method(line_search_method),
     step_size_reduction_rate(step_size_reduction_rate),
     min_step_size(min_step_size),
     armijo_control_rate(armijo_control_rate),
-    margin_rate(margin_rate) {
+    margin_rate(margin_rate),
+    eps(eps) {
   try {
     if (line_search_method != "filter" && line_search_method != "merit-backtracking") {
       throw std::out_of_range("invalid value: line_search_method must be either \"filter\" or \"merit-backtracking\"!");
@@ -53,7 +55,7 @@ LineSearchSettings::~LineSearchSettings() {
 }
 
 LineSearchSettings LineSearchSettings::defaultSettings() {
-  LineSearchSettings s("filter", 0.75, 0.05, 0.001, 0.05);
+  LineSearchSettings s("filter", 0.75, 0.05, 0.001, 0.05, 1.0e-08);
   return s;
 }
 

--- a/src/line_search/line_search_settings.cpp
+++ b/src/line_search/line_search_settings.cpp
@@ -1,0 +1,60 @@
+#include "robotoc/line_search/line_search_settings.hpp"
+
+#include <cassert>
+#include <stdexcept>
+#include <iostream>
+
+
+namespace robotoc {
+
+LineSearchSettings::LineSearchSettings(const std::string& line_search_method,
+                                       const double step_size_reduction_rate, 
+                                       const double min_step_size, 
+                                       const double armijo_control_rate,
+                                       const double margin_rate)
+  : line_search_method(line_search_method),
+    step_size_reduction_rate(step_size_reduction_rate),
+    min_step_size(min_step_size),
+    armijo_control_rate(armijo_control_rate),
+    margin_rate(margin_rate) {
+  try {
+    if (line_search_method != "filter" && line_search_method != "merit-backtracking") {
+      throw std::out_of_range("invalid value: line_search_method must be either \"filter\" or \"merit-backtracking\"!");
+    }
+    if (step_size_reduction_rate <= 0) {
+      throw std::out_of_range("invalid value: step_size_reduction_rate must be positive!");
+    }
+    if (min_step_size <= 0) {
+      throw std::out_of_range("invalid value: min_step_size must be positive!");
+    }
+    if (armijo_control_rate <= 0) {
+      throw std::out_of_range("invalid value: min_step_size must be positive!");
+    }
+    if (margin_rate <= 0) {
+      throw std::out_of_range("invalid value: margin_rate must be positive!");
+    }
+  }
+  catch(const std::exception& e) {
+    std::cerr << e.what() << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+LineSearchSettings::LineSearchSettings() 
+  : line_search_method(),
+    step_size_reduction_rate(0),
+    min_step_size(0),
+    armijo_control_rate(0),
+    margin_rate(0) {
+}
+
+
+LineSearchSettings::~LineSearchSettings() {
+}
+
+LineSearchSettings LineSearchSettings::defaultSettings() {
+  LineSearchSettings s("filter", 0.75, 0.05, 0.001, 0.05);
+  return s;
+}
+
+} // namespace robotoc

--- a/src/solver/ocp_solver.cpp
+++ b/src/solver/ocp_solver.cpp
@@ -379,6 +379,10 @@ void OCPSolver::discretizeSolution() {
   }
 }
 
+ void OCPSolver::setLineSearchSettings(const LineSearchSettings& settings) {
+   line_search_.set(settings);
+ }
+
 
 void OCPSolver::disp(std::ostream& os) const {
   os << contact_sequence_ << std::endl;

--- a/src/solver/ocp_solver.cpp
+++ b/src/solver/ocp_solver.cpp
@@ -379,9 +379,9 @@ void OCPSolver::discretizeSolution() {
   }
 }
 
- void OCPSolver::setLineSearchSettings(const LineSearchSettings& settings) {
-   line_search_.set(settings);
- }
+void OCPSolver::setLineSearchSettings(const LineSearchSettings& settings) {
+  line_search_.set(settings);
+}
 
 
 void OCPSolver::disp(std::ostream& os) const {

--- a/test/line_search/line_search_test.cpp
+++ b/test/line_search/line_search_test.cpp
@@ -129,8 +129,8 @@ TEST_P(LineSearchTest, floatingBase) {
   test(robot, settings);
 }
 
-LineSearchSettings filter_settings("filter", 0.75, 0.05, 0.001, 0.05);
-LineSearchSettings backtrack_settings("merit-backtracking", 0.75, 0.05, 0.001, 0.05);
+LineSearchSettings filter_settings = LineSearchSettings::defaultSettings();
+LineSearchSettings backtrack_settings("merit-backtracking", 0.75, 0.05, 0.001, 0.05, 1.0e-08);
 
 INSTANTIATE_TEST_SUITE_P(ParamtererizedTest, LineSearchTest, 
                          ::testing::Values(filter_settings, backtrack_settings));

--- a/test/line_search/line_search_test.cpp
+++ b/test/line_search/line_search_test.cpp
@@ -9,6 +9,7 @@
 #include "robotoc/ocp/ocp.hpp"
 #include "robotoc/ocp/direct_multiple_shooting.hpp"
 #include "robotoc/line_search/line_search_filter.hpp"
+#include "robotoc/line_search/line_search_settings.hpp"
 #include "robotoc/line_search/line_search.hpp"
 
 #include "test_helper.hpp"
@@ -22,7 +23,7 @@
 
 namespace robotoc {
 
-class LineSearchTest : public ::testing::Test {
+class LineSearchTest : public ::testing::TestWithParam<LineSearchSettings> {
 protected:
   virtual void SetUp() {
     srand((unsigned int) time(0));
@@ -47,7 +48,7 @@ protected:
                             const std::shared_ptr<ContactSequence>& contact_sequence) const;
   std::shared_ptr<ContactSequence> createContactSequence(const Robot& robot) const;
 
-  void test(const Robot& robot) const;
+  void test(const Robot& robot, const LineSearchSettings& settings) const;
 
   int N, max_num_impulse, nthreads;
   double T, t, dt, step_size_reduction_rate, min_step_size;
@@ -81,7 +82,7 @@ std::shared_ptr<ContactSequence> LineSearchTest::createContactSequence(const Rob
 }
 
 
-void LineSearchTest::test(const Robot& robot) const {
+void LineSearchTest::test(const Robot& robot, const LineSearchSettings& settings) const {
   auto cost = testhelper::CreateCost(robot);
   auto constraints = testhelper::CreateConstraints(robot);
   const auto contact_sequence = createContactSequence(robot);
@@ -96,33 +97,43 @@ void LineSearchTest::test(const Robot& robot) const {
   ocp.discretize(contact_sequence, t);
   DirectMultipleShooting dms(N, max_num_impulse, nthreads);
   dms.initConstraints(ocp, robots, contact_sequence, s);
-  LineSearch line_search(robot, N, max_num_impulse, nthreads);
+  LineSearch line_search(robot, N, max_num_impulse, nthreads, settings);
   EXPECT_TRUE(line_search.isFilterEmpty());
   const double max_primal_step_size = min_step_size + std::abs(Eigen::VectorXd::Random(1)[0]) * (1-min_step_size);
   const double step_size = line_search.computeStepSize(ocp, robots, contact_sequence, q, v, s, d, max_primal_step_size);
   EXPECT_TRUE(step_size <= max_primal_step_size);
   EXPECT_TRUE(step_size >= min_step_size);
-  EXPECT_FALSE(line_search.isFilterEmpty());
+  if (settings.line_search_method == "filter") {
+    EXPECT_FALSE(line_search.isFilterEmpty());
+  }
   const double very_small_max_primal_step_size = min_step_size * std::abs(Eigen::VectorXd::Random(1)[0]);
   EXPECT_DOUBLE_EQ(line_search.computeStepSize(ocp, robots, contact_sequence, q, v, s, d, very_small_max_primal_step_size),
                    min_step_size);
 }
 
 
-TEST_F(LineSearchTest, fixedBase) {
+TEST_P(LineSearchTest, fixedBase) {
   auto robot = testhelper::CreateFixedBaseRobot();
-  test(robot);
+  auto settings = GetParam();
+  test(robot, settings);
   robot = testhelper::CreateFixedBaseRobot(dt);
-  test(robot);
+  test(robot, settings);
 }
 
 
-TEST_F(LineSearchTest, floatingBase) {
+TEST_P(LineSearchTest, floatingBase) {
   auto robot = testhelper::CreateFloatingBaseRobot();
-  test(robot);
+  auto settings = GetParam();
+  test(robot, settings);
   robot = testhelper::CreateFloatingBaseRobot(dt);
-  test(robot);
+  test(robot, settings);
 }
+
+LineSearchSettings filter_settings("filter", 0.75, 0.05, 0.001, 0.05);
+LineSearchSettings backtrack_settings("merit-backtracking", 0.75, 0.05, 0.001, 0.05);
+
+INSTANTIATE_TEST_SUITE_P(ParamtererizedTest, LineSearchTest, 
+                         ::testing::Values(filter_settings, backtrack_settings));
 
 } // namespace robotoc
 


### PR DESCRIPTION
https://github.com/mayataka/idocp/issues/55

hi @mayataka, this is my attempt to add backtracking line search based on my understandings below:

- KKT residuals are the gradients for the objective function and the constraint violations. Thus, we can get a directional derivative by computing a dot product of the residual and the direction.
- In `SplitOCP`,  the directional derivative is `lx・dx + la・da + lu・du + lf・df`. It is `lx・dx` in `TerminalOCP` and `lx・dx + ldv・ddv + lf・df` in `ImpulseSplitOCP`.
- For a problem with multiple time stages, we will accept the step size if the sum of lhs values in the Armijo conditions for each stages are smaller than the sum of rhs values.

Could you check if I am in the right direction?